### PR TITLE
Make overwhelm AI lobby-time configurable

### DIFF
--- a/hook/loc/CZ/strings_db.lua
+++ b/hook/loc/CZ/strings_db.lua
@@ -96,3 +96,9 @@ aisettingsUveso_0200="No Marker"
 aisettingsUveso_0201="Use the c-engine to path the way (20%% slower)"
 aisettingsUveso_0202="Print to game.log"
 aisettingsUveso_0203="Print the marker masterchain to the game.log for copy&paste"
+
+aisettingsUveso_0222="AIx Overwhelm cheat increase"
+aisettingsUveso_0223="Set the cheat multiplier increase for the AIx Overwhelm. The multiplier is increased every minute with this value"
+
+aisettingsUveso_0224="AIx Overwhelm start time"
+aisettingsUveso_0225="Set the delay in minutes before the AIx Overwhelm starts to increase the cheat multiplier"

--- a/hook/loc/DE/strings_db.lua
+++ b/hook/loc/DE/strings_db.lua
@@ -96,3 +96,9 @@ aisettingsUveso_0200="Keine Marker"
 aisettingsUveso_0201="Benutzt die c-engine für Wegfindung (20%% langsamer)"
 aisettingsUveso_0202="Drucke Marker ins game.log"
 aisettingsUveso_0203="Druckt die Marker MasterChain Tabelle zum Ausschneiden & Einfügen in das game.log"
+
+aisettingsUveso_0222="KIx Brecher Cheat Zunahme"
+aisettingsUveso_0223="Stellen Sie die Erhöhung des Cheat-Multiplikators für den KIx Brecher ein. Der Multiplikator wird mit diesem Wert jede Minute erhöht"
+
+aisettingsUveso_0224="KIx Brecher startzeit"
+aisettingsUveso_0225="Stellen Sie die Verzögerung in Minuten ein, bevor der KIx Brecher beginnt, den Cheat-Multiplikator zu erhöhen"

--- a/hook/loc/ES/strings_db.lua
+++ b/hook/loc/ES/strings_db.lua
@@ -96,3 +96,9 @@ aisettingsUveso_0200="No Marker"
 aisettingsUveso_0201="Use the c-engine to path the way (20%% slower)"
 aisettingsUveso_0202="Print to game.log"
 aisettingsUveso_0203="Print the marker masterchain to the game.log for copy&paste"
+
+aisettingsUveso_0222="AIx Overwhelm cheat increase"
+aisettingsUveso_0223="Set the cheat multiplier increase for the AIx Overwhelm. The multiplier is increased every minute with this value"
+
+aisettingsUveso_0224="AIx Overwhelm start time"
+aisettingsUveso_0225="Set the delay in minutes before the AIx Overwhelm starts to increase the cheat multiplier"

--- a/hook/loc/FR/strings_db.lua
+++ b/hook/loc/FR/strings_db.lua
@@ -96,3 +96,9 @@ aisettingsUveso_0200="No Marker"
 aisettingsUveso_0201="Use the c-engine to path the way (20%% slower)"
 aisettingsUveso_0202="Print to game.log"
 aisettingsUveso_0203="Print the marker masterchain to the game.log for copy&paste"
+
+aisettingsUveso_0222="AIx Overwhelm cheat increase"
+aisettingsUveso_0223="Set the cheat multiplier increase for the AIx Overwhelm. The multiplier is increased every minute with this value"
+
+aisettingsUveso_0224="AIx Overwhelm start time"
+aisettingsUveso_0225="Set the delay in minutes before the AIx Overwhelm starts to increase the cheat multiplier"

--- a/hook/loc/IT/strings_db.lua
+++ b/hook/loc/IT/strings_db.lua
@@ -96,3 +96,9 @@ aisettingsUveso_0200="No Marker"
 aisettingsUveso_0201="Use the c-engine to path the way (20%% slower)"
 aisettingsUveso_0202="Print to game.log"
 aisettingsUveso_0203="Print the marker masterchain to the game.log for copy&paste"
+
+aisettingsUveso_0222="AIx Overwhelm cheat increase"
+aisettingsUveso_0223="Set the cheat multiplier increase for the AIx Overwhelm. The multiplier is increased every minute with this value"
+
+aisettingsUveso_0224="AIx Overwhelm start time"
+aisettingsUveso_0225="Set the delay in minutes before the AIx Overwhelm starts to increase the cheat multiplier"

--- a/hook/loc/PL/strings_db.lua
+++ b/hook/loc/PL/strings_db.lua
@@ -96,3 +96,9 @@ aisettingsUveso_0200="No Marker"
 aisettingsUveso_0201="Use the c-engine to path the way (20%% slower)"
 aisettingsUveso_0202="Print to game.log"
 aisettingsUveso_0203="Print the marker masterchain to the game.log for copy&paste"
+
+aisettingsUveso_0222="AIx Overwhelm cheat increase"
+aisettingsUveso_0223="Set the cheat multiplier increase for the AIx Overwhelm. The multiplier is increased every minute with this value"
+
+aisettingsUveso_0224="AIx Overwhelm start time"
+aisettingsUveso_0225="Set the delay in minutes before the AIx Overwhelm starts to increase the cheat multiplier"

--- a/hook/loc/RU/strings_db.lua
+++ b/hook/loc/RU/strings_db.lua
@@ -96,3 +96,9 @@ aisettingsUveso_0200="No Marker"
 aisettingsUveso_0201="Use the c-engine to path the way (20%% slower)"
 aisettingsUveso_0202="Print to game.log"
 aisettingsUveso_0203="Print the marker masterchain to the game.log for copy&paste"
+
+aisettingsUveso_0222="AIx Overwhelm cheat increase"
+aisettingsUveso_0223="Set the cheat multiplier increase for the AIx Overwhelm. The multiplier is increased every minute with this value"
+
+aisettingsUveso_0224="AIx Overwhelm start time"
+aisettingsUveso_0225="Set the delay in minutes before the AIx Overwhelm starts to increase the cheat multiplier"

--- a/hook/loc/TZM/strings_db.lua
+++ b/hook/loc/TZM/strings_db.lua
@@ -96,3 +96,9 @@ aisettingsUveso_0200="No Marker"
 aisettingsUveso_0201="Use the c-engine to path the way (20%% slower)"
 aisettingsUveso_0202="Print to game.log"
 aisettingsUveso_0203="Print the marker masterchain to the game.log for copy&paste"
+
+aisettingsUveso_0222="AIx Overwhelm cheat increase"
+aisettingsUveso_0223="Set the cheat multiplier increase for the AIx Overwhelm. The multiplier is increased every minute with this value"
+
+aisettingsUveso_0224="AIx Overwhelm start time"
+aisettingsUveso_0225="Set the delay in minutes before the AIx Overwhelm starts to increase the cheat multiplier"

--- a/hook/loc/US/strings_db.lua
+++ b/hook/loc/US/strings_db.lua
@@ -96,3 +96,9 @@ aisettingsUveso_0200="No Marker"
 aisettingsUveso_0201="Use the c-engine to path the way (20%% slower)"
 aisettingsUveso_0202="Print to game.log"
 aisettingsUveso_0203="Print the marker masterchain to the game.log for copy&paste"
+
+aisettingsUveso_0222="AIx Overwhelm cheat increase"
+aisettingsUveso_0223="Set the cheat multiplier increase for the AIx Overwhelm. The multiplier is increased every minute with this value"
+
+aisettingsUveso_0224="AIx Overwhelm start time"
+aisettingsUveso_0225="Set the delay in minutes before the AIx Overwhelm starts to increase the cheat multiplier"

--- a/hook/lua/AI/aiarchetype-managerloader.lua
+++ b/hook/lua/AI/aiarchetype-managerloader.lua
@@ -119,10 +119,10 @@ function EcoManagerThread(aiBrain)
         -- Cheatbuffs
         if personality == 'uvesooverwhelm' then
             -- Check every 60 seconds
-            if (GetGameTimeSeconds() > 60 * 20) and lastCall+60 < GetGameTimeSeconds() then
+            if (GetGameTimeSeconds() > ScenarioInfo.Options.AIOverwhelmDelay * 60) and lastCall+60 < GetGameTimeSeconds() then
                 lastCall = GetGameTimeSeconds()
-                aiBrain.CheatMult = aiBrain.CheatMult + 0.025 -- +0.1 after 4 min. +1.0 after 40 min.
-                aiBrain.BuildMult = aiBrain.BuildMult + 0.025
+                aiBrain.CheatMult = aiBrain.CheatMult + ScenarioInfo.Options.AIOverwhelmIncrease  -- with the default of 0.025, +0.1 after 4 min. +1.0 after 40 min.
+                aiBrain.BuildMult = aiBrain.BuildMult + ScenarioInfo.Options.AIOverwhelmIncrease
                 if aiBrain.CheatMult > 8 then aiBrain.CheatMult = 8 end
                 if aiBrain.BuildMult > 8 then aiBrain.BuildMult = 8 end
                 --SPEW('Setting new values for aiBrain.CheatMult:'..aiBrain.CheatMult..' - aiBrain.BuildMult:'..aiBrain.BuildMult)

--- a/lua/AI/LobbyOptions/lobbyoptions.lua
+++ b/lua/AI/LobbyOptions/lobbyoptions.lua
@@ -105,6 +105,102 @@ AIOpts = {
         },
     },
     {
+        default = 2,
+        label = "<LOC aisettingsUveso_0222>AI overwhelm increase",
+        help = "<LOC aisettingsUveso_0223>Increase the Overwhelm's resource and build speed multiplier every minute with this value",
+        key = 'AIOverwhelmIncrease',
+        values = {
+            {
+                text = "0.0125",
+                help = "0.0125",
+                key = 0.0125,
+            },
+            {
+                text = "0.025",
+                help = "0.025",
+                key = 0.025,
+            },
+            {
+                text = "0.0375",
+                help = "0.0375",
+                key = 0.0376,
+            },
+            {
+                text = "0.05",
+                help = "0.05",
+                key = 0.05,
+            },
+            {
+                text = "0.0625",
+                help = "0.0625",
+                key = 0.0625,
+            },
+            {
+                text = "0.075",
+                help = "0.075",
+                key = 0.075,
+            },
+            {
+                text = "0.0875",
+                help = "0.0875",
+                key = 0.0875,
+            },
+            {
+                text = "0.1",
+                help = "0.1",
+                key = 0.1,
+            },
+        },
+    },
+    {
+        default = 5,
+        label = "<LOC aisettingsUveso_0224>AIx Overwhelm start time",
+        help = "<LOC aisettingsUveso_0225>Set the delay in minutes before the AIx Overwhelm starts to increase the cheat multiplier",
+        key = 'AIOverwhelmDelay',
+        values = {
+            {
+                text = "5",
+                help = "5",
+                key = 5,
+            },
+            {
+                text = "7",
+                help = "7",
+                key = 7,
+            },
+            {
+                text = "10",
+                help = "10",
+                key = 10,
+            },
+            {
+                text = "15",
+                help = "15",
+                key = 15,
+            },
+            {
+                text = "20",
+                help = "20",
+                key = 20,
+            },
+            {
+                text = "25",
+                help = "25",
+                key = 25,
+            },
+            {
+                text = "30",
+                help = "30",
+                key = 30,
+            },
+            {
+                text = "45",
+                help = "45",
+                key = 45,
+            },
+        },
+    },
+    {
         default = 1,
         label = "<LOC aisettingsUveso_0167>DEBUG: AI Platoon names",
         help = "<LOC aisettingsUveso_0168>Displays Platoon and AI plan name",


### PR DESCRIPTION
Hi,

First of all, thank you for the work you've put into this AI. Me and my friends enjoy playing against it PvE-style.

This pull request makes the difficulty of the overwhelm sub-AI more configurable. Both the AIx cheat multiplier increase and the game time at which it starts to increase become configurable. For us the default settings of the overwhelm AI are an easy win, with these changes it can be configured to be significantly more challenging. I've left the default settings at the previous hard-coded values so that nothing changes for existing users.

I gave the German localization my best shot with the help of Google translate, feel free to push to my branch with more suitable/correct translations :smile: 

We've tested these modifications by pitching a regular AIx-adaptive against an AIx-overwhelm with the cheat multiplier set to 1.0, the delay to 5 mins and the increase to 0.1. The overwhelm's resource multiplier is increased every minute starting at 5 minutes in game, easily visible on the hydro plant. The adaptive AI seems receive the new bonus for newly built structures, which I guess is due to the cheat multiplier being a global value?

As this is my first time trying to mod Lua for Forged Alliance, please let me know if I screwed up somewhere :innocent: